### PR TITLE
Fix race conditions with starting/ending secure sessions

### DIFF
--- a/src/org/smssecure/smssecure/ConversationActivity.java
+++ b/src/org/smssecure/smssecure/ConversationActivity.java
@@ -387,8 +387,9 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     builder.setPositiveButton(R.string.yes, new DialogInterface.OnClickListener() {
       @Override
       public void onClick(DialogInterface dialog, int which) {
-        KeyExchangeInitiator.initiate(ConversationActivity.this, masterSecret,
-                                      recipient, true);
+        if (!isEncryptedConversation){
+          KeyExchangeInitiator.initiate(ConversationActivity.this, masterSecret, recipient, true);
+        }
       }
     });
 
@@ -405,7 +406,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     builder.setPositiveButton(R.string.yes, new DialogInterface.OnClickListener() {
       @Override
       public void onClick(DialogInterface dialog, int which) {
-        if (isSingleConversation()) {
+        if (isSingleConversation() && isEncryptedConversation) {
           final Context context = getApplicationContext();
 
           OutgoingEndSessionMessage endSessionMessage =


### PR DESCRIPTION
The user could end a session, but before it actually ended, click the end session button again and get into a bad state.

This also fixes the opposite case (where the user has a secure session and tries to start one).