### PR TITLE
Detect identical identitiy keys

### DIFF
--- a/src/org/smssecure/smssecure/ConversationActivity.java
+++ b/src/org/smssecure/smssecure/ConversationActivity.java
@@ -28,7 +28,6 @@ import android.os.Build;
 import android.os.Bundle;
 import android.provider.ContactsContract;
 import android.telephony.PhoneNumberUtils;
-import android.telephony.TelephonyManager;
 import android.text.Editable;
 import android.text.InputType;
 import android.text.TextUtils;
@@ -101,6 +100,7 @@ import org.smssecure.smssecure.util.Emoji;
 import org.smssecure.smssecure.util.GroupUtil;
 import org.smssecure.smssecure.util.MemoryCleaner;
 import org.smssecure.smssecure.util.SMSSecurePreferences;
+import org.smssecure.smssecure.util.TelephonyUtil;
 import org.smssecure.smssecure.util.Util;
 import org.whispersystems.libaxolotl.InvalidMessageException;
 import org.whispersystems.libaxolotl.util.guava.Optional;
@@ -363,15 +363,10 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
       return;
     }
 
-    TelephonyManager phoneDetails = (TelephonyManager)getApplicationContext().getSystemService(Context.TELEPHONY_SERVICE);
-    if (recipients.getPrimaryRecipient().getNumber() != null){
-      String recipienNumber = recipients.getPrimaryRecipient().getNumber();
-      String phoneNumber    = phoneDetails.getLine1Number();
-      if (recipienNumber.equals(phoneNumber)){
-        Toast.makeText(this, getString(R.string.ConversationActivity_recipient_self),
-                       Toast.LENGTH_LONG).show();
-        return;
-      }
+    if (TelephonyUtil.isMyPhoneNumber(this, recipients.getPrimaryRecipient().getNumber())) {
+      Toast.makeText(this, getString(R.string.ConversationActivity_recipient_self),
+              Toast.LENGTH_LONG).show();
+      return;
     }
 
     final Recipient recipient   = getRecipients().getPrimaryRecipient();

--- a/src/org/smssecure/smssecure/ConversationItem.java
+++ b/src/org/smssecure/smssecure/ConversationItem.java
@@ -67,6 +67,7 @@ import org.smssecure.smssecure.util.Emoji;
 import org.smssecure.smssecure.util.FutureTaskListener;
 import org.smssecure.smssecure.util.ListenableFutureTask;
 import org.smssecure.smssecure.util.ResUtil;
+import org.smssecure.smssecure.util.TelephonyUtil;
 
 import java.util.Set;
 
@@ -403,6 +404,7 @@ public class ConversationItem extends LinearLayout {
 
   private void checkForAutoInitiate(final Recipient recipient, String body, long threadId) {
     if (!groupThread &&
+        !TelephonyUtil.isMyPhoneNumber(context, recipient.getNumber()) &&
         AutoInitiate.isValidAutoInitiateSituation(context, masterSecret, recipient, body, threadId))
     {
       AutoInitiate.exemptThread(context, threadId);

--- a/src/org/smssecure/smssecure/util/TelephonyUtil.java
+++ b/src/org/smssecure/smssecure/util/TelephonyUtil.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.res.Configuration;
 import android.net.ConnectivityManager;
 import android.telephony.TelephonyManager;
+import android.telephony.PhoneNumberUtils;
 import android.util.Log;
 
 public class TelephonyUtil {
@@ -36,5 +37,14 @@ public class TelephonyUtil {
   public static String getApn(final Context context) {
     final ConnectivityManager cm = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
     return cm.getNetworkInfo(ConnectivityManager.TYPE_MOBILE_MMS).getExtraInfo();
+  }
+
+  public static boolean isMyPhoneNumber(final Context context, String number){
+    return number != null && PhoneNumberUtils.compare(context, getPhoneNumber(context), number);
+  }
+
+  public static String getPhoneNumber(final Context context){
+    final TelephonyManager tm = (TelephonyManager)context.getSystemService(Context.TELEPHONY_SERVICE);
+    return tm.getLine1Number();
   }
 }


### PR DESCRIPTION
Instead of checking the phone number, just check the identity in the key exchange the other end sends back and invalidate the exchange if it's the same.

Since the identity key is 33 bytes = 264 bits of entropy, the odds that two people will have the same keys are miniscule.

Still though, I'm not convinced this is the right way to do this.