### PR TITLE
Put Travis CI builds online

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,6 @@ before_script:
 script:
      - ./scripts/build-witness.sh
      - ./gradlew connectedCheck -PdisablePreDex -PtaskThreads=1 -PandroidThread=1
+
+after_success:
+     - ./scripts/travis-upload.sh $KEY

--- a/scripts/travis-upload.sh
+++ b/scripts/travis-upload.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# Upload a build to files.smssecure.org
+# usage: ./travis-upload <key>
+
+set -eo pipefail
+
+if [ "$#" -lt 1 ]; then
+    echo "usage: ./travis-upload <key>"
+    exit 1
+fi
+
+if [ `basename $(pwd)` = "scripts" ]; then
+    cd ..
+fi
+
+if [ ! -f "./build/outputs/apk/SMSSecure-debug.apk" ]; then
+    echo "APK not found. Did you run `./gradlew build`?"
+    exit 1
+fi
+
+COMMIT=$(git rev-parse --short HEAD)
+curl --form "fileupload=@./build/outputs/apk/SMSSecure-debug.apk;filename=SMSSecure-debug-$COMMIT.apk" -H "Authorization: KEY $1" https://files.smssecure.org/receive_apk


### PR DESCRIPTION
After a successful build, Travis CI will upload the built APK to files.smssecure.org. The source code of files.smssecure.org is available here: https://github.com/SMSSecure/files.smssecure.org. It works with a secret key stored in Travis's settings. The build won't fail if files.smssecure.org is down.