### PR TITLE
Remove push code in bubble's state

### DIFF
--- a/src/org/smssecure/smssecure/ConversationItem.java
+++ b/src/org/smssecure/smssecure/ConversationItem.java
@@ -201,8 +201,6 @@ public class ConversationItem extends LinearLayout {
         messageRecord.isPendingInsecureSmsFallback())
     {
       transportationState = BubbleContainer.TRANSPORT_STATE_SMS_PENDING;
-    } else if (messageRecord.isPush()) {
-      transportationState = BubbleContainer.TRANSPORT_STATE_PUSH_SENT;
     } else {
       transportationState = BubbleContainer.TRANSPORT_STATE_SMS_SENT;
     }

--- a/src/org/smssecure/smssecure/components/BubbleContainer.java
+++ b/src/org/smssecure/smssecure/components/BubbleContainer.java
@@ -36,16 +36,14 @@ public abstract class BubbleContainer extends RelativeLayout {
   @SuppressWarnings("unused")
   private static final String TAG = BubbleContainer.class.getSimpleName();
 
-  public static final int TRANSPORT_STATE_PUSH_SENT    = 0;
-  public static final int TRANSPORT_STATE_SMS_SENT     = 1;
-  public static final int TRANSPORT_STATE_SMS_PENDING  = 2;
-  public static final int TRANSPORT_STATE_PUSH_PENDING = 3;
+  public static final int TRANSPORT_STATE_SMS_SENT    = 1;
+  public static final int TRANSPORT_STATE_SMS_PENDING = 2;
 
   public static final int MEDIA_STATE_NO_MEDIA    = 0;
   public static final int MEDIA_STATE_CAPTIONLESS = 1;
   public static final int MEDIA_STATE_CAPTIONED   = 2;
 
-  @IntDef({TRANSPORT_STATE_PUSH_SENT, TRANSPORT_STATE_PUSH_PENDING, TRANSPORT_STATE_SMS_SENT, TRANSPORT_STATE_SMS_PENDING})
+  @IntDef({TRANSPORT_STATE_SMS_SENT, TRANSPORT_STATE_SMS_PENDING})
   public @interface TransportState {}
 
   @IntDef({MEDIA_STATE_NO_MEDIA, MEDIA_STATE_CAPTIONLESS, MEDIA_STATE_CAPTIONED})
@@ -166,6 +164,6 @@ public abstract class BubbleContainer extends RelativeLayout {
   }
 
   private boolean isPending(@TransportState int transportState) {
-    return transportState == TRANSPORT_STATE_PUSH_PENDING || transportState == TRANSPORT_STATE_SMS_PENDING;
+    return transportState == TRANSPORT_STATE_SMS_PENDING;
   }
 }

--- a/src/org/smssecure/smssecure/components/OutgoingBubbleContainer.java
+++ b/src/org/smssecure/smssecure/components/OutgoingBubbleContainer.java
@@ -45,10 +45,8 @@ public class OutgoingBubbleContainer extends BubbleContainer {
                                                                   R.attr.triangle_tick_outgoing_pending_push};
 
   private static final SparseIntArray TRANSPORT_STYLE_MAP = new SparseIntArray(TRANSPORT_STYLE_ATTRIBUTES.length) {{
-    put(TRANSPORT_STATE_PUSH_SENT, 0);
     put(TRANSPORT_STATE_SMS_SENT, 1);
     put(TRANSPORT_STATE_SMS_PENDING, 2);
-    put(TRANSPORT_STATE_PUSH_PENDING, 3);
   }};
 
   private TypedArray styledDrawables;


### PR DESCRIPTION
```
$ find . -type f | xargs grep "TRANSPORT_STATE_PUSH"
./src/org/smssecure/smssecure/ConversationItem.java:      transportationState = BubbleContainer.TRANSPORT_STATE_PUSH_SENT;
./src/org/smssecure/smssecure/components/OutgoingBubbleContainer.java:    put(TRANSPORT_STATE_PUSH_SENT, 0);
./src/org/smssecure/smssecure/components/OutgoingBubbleContainer.java:    put(TRANSPORT_STATE_PUSH_PENDING, 3);
./src/org/smssecure/smssecure/components/BubbleContainer.java:  public static final int TRANSPORT_STATE_PUSH_SENT    = 0;
./src/org/smssecure/smssecure/components/BubbleContainer.java:  public static final int TRANSPORT_STATE_PUSH_PENDING = 3;
./src/org/smssecure/smssecure/components/BubbleContainer.java:  @IntDef({TRANSPORT_STATE_PUSH_SENT, TRANSPORT_STATE_PUSH_PENDING, TRANSPORT_STATE_SMS_SENT, TRANSPORT_STATE_SMS_PENDING})
./src/org/smssecure/smssecure/components/BubbleContainer.java:    return transportState == TRANSPORT_STATE_PUSH_PENDING || transportState == TRANSPORT_STATE_SMS_PENDING;
```