### PR TITLE
Secure session ended message

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -265,7 +265,6 @@
 
     <!-- ThreadRecord -->
     <string name="ThreadRecord_left_the_group">Left the group...</string>
-    <string name="TheadRecord_secure_session_ended">Secure session ended.</string>
     <string name="ThreadRecord_draft">Draft:</string>
 
     <!-- VerifyIdentityActivity -->
@@ -299,6 +298,7 @@
     <string name="MessageDisplayHelper_bad_encrypted_message">Bad encrypted message...</string>
     <string name="MessageDisplayHelper_decrypting_please_wait">Decrypting, please wait...</string>
     <string name="MessageDisplayHelper_message_encrypted_for_non_existing_session">Message encrypted for non-existing session...</string>
+    <string name="MessageDisplayHelper_end_session_encrypted_for_non_existing_session">End session request encrypted for non-existing session...</string>
 
     <!-- EncryptingSmsDatabase -->
     <string name="EncryptingSmsDatabase_error_decrypting_message">Error decrypting message.</string>

--- a/src/org/smssecure/smssecure/database/model/SmsMessageRecord.java
+++ b/src/org/smssecure/smssecure/database/model/SmsMessageRecord.java
@@ -85,7 +85,11 @@ public class SmsMessageRecord extends MessageRecord {
     } else if (SmsDatabase.Types.isDecryptInProgressType(type)) {
       return emphasisAdded(context.getString(R.string.MessageDisplayHelper_decrypting_please_wait));
     } else if (SmsDatabase.Types.isNoRemoteSessionType(type)) {
-      return emphasisAdded(context.getString(R.string.MessageDisplayHelper_message_encrypted_for_non_existing_session));
+      if (SmsDatabase.Types.isEndSessionType(type)) {
+        return emphasisAdded(context.getString(R.string.MessageDisplayHelper_end_session_encrypted_for_non_existing_session));
+      } else {
+        return emphasisAdded(context.getString(R.string.MessageDisplayHelper_message_encrypted_for_non_existing_session));
+      }
     } else if (!getBody().isPlaintext()) {
       return emphasisAdded(context.getString(R.string.MessageNotifier_encrypted_message));
     } else if (SmsDatabase.Types.isEndSessionType(type)) {

--- a/src/org/smssecure/smssecure/database/model/ThreadRecord.java
+++ b/src/org/smssecure/smssecure/database/model/ThreadRecord.java
@@ -65,11 +65,15 @@ public class ThreadRecord extends DisplayRecord {
     } else if (SmsDatabase.Types.isFailedDecryptType(type)) {
       return emphasisAdded(context.getString(R.string.MessageDisplayHelper_bad_encrypted_message));
     } else if (SmsDatabase.Types.isNoRemoteSessionType(type)) {
-      return emphasisAdded(context.getString(R.string.MessageDisplayHelper_message_encrypted_for_non_existing_session));
+      if (SmsDatabase.Types.isEndSessionType(type)) {
+        return emphasisAdded(context.getString(R.string.MessageDisplayHelper_end_session_encrypted_for_non_existing_session));
+      } else {
+        return emphasisAdded(context.getString(R.string.MessageDisplayHelper_message_encrypted_for_non_existing_session));
+      }
     } else if (!getBody().isPlaintext()) {
       return emphasisAdded(context.getString(R.string.MessageNotifier_encrypted_message));
     } else if (SmsDatabase.Types.isEndSessionType(type)) {
-      return emphasisAdded(context.getString(R.string.TheadRecord_secure_session_ended));
+      return emphasisAdded(context.getString(R.string.SmsMessageRecord_secure_session_ended));
     } else if (MmsSmsColumns.Types.isLegacyType(type)) {
       return emphasisAdded(context.getString(R.string.MessageRecord_message_encrypted_with_a_legacy_protocol_version_that_is_no_longer_supported));
     } else if (MmsSmsColumns.Types.isDraftMessageType(type)) {


### PR DESCRIPTION
If a person sends you a request to end a secure session that you don't know exists, you will see a "secure session ended" notification, but in the conversation see "Message encrypted for non-existing session". 

The app clearly knows that it was a request to end the non-existing session (not just a regular message) so should state that in the message as well as the notification.