### PR TITLE
Whitespace tagging causing issues with SMS-based services

### DIFF
--- a/src/org/smssecure/smssecure/ConversationActivity.java
+++ b/src/org/smssecure/smssecure/ConversationActivity.java
@@ -1012,8 +1012,11 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     if (rawText.length() < 1 && !attachmentManager.isAttachmentPresent())
       throw new InvalidMessageException(getString(R.string.ConversationActivity_message_is_empty_exclamation));
 
-    if (!isEncryptedConversation && AutoInitiate.isTaggable(rawText))
+    if (!isEncryptedConversation &&
+        AutoInitiate.isTaggableMessage(rawText) &&
+        AutoInitiate.isTaggableDestination(getRecipients())) {
       rawText = AutoInitiate.getTaggedMessage(rawText);
+    }
 
     return rawText;
   }


### PR DESCRIPTION
[![CallYa Toppings](http://toppings.vodafone.de/img/topping-fb.jpg)](http://toppings.vodafone.de/)

I am always having problems redeeming my toppings with Vodafone. I already filed that Issue on https://github.com/WhisperSystems/TextSecure/issues/1780, but they were very reluctant to even cope with fixing it. I was wondering if you guys might be a little more open towards this Issue, which very likely does not just happen to be mine?