### PR TITLE
Manual completion of key exchanges is broken

### DIFF
--- a/src/org/smssecure/smssecure/ReceiveKeyActivity.java
+++ b/src/org/smssecure/smssecure/ReceiveKeyActivity.java
@@ -211,7 +211,7 @@ public class ReceiveKeyActivity extends PassphraseRequiredActionBarActivity {
           } else {
             ApplicationContext.getInstance(context)
                               .getJobManager()
-                              .add(new SmsDecryptJob(context, messageId));
+                              .add(new SmsDecryptJob(context, messageId, true));
           }
 
           return null;

--- a/src/org/smssecure/smssecure/jobs/SmsDecryptJob.java
+++ b/src/org/smssecure/smssecure/jobs/SmsDecryptJob.java
@@ -42,15 +42,21 @@ public class SmsDecryptJob extends MasterSecretJob {
 
   private static final String TAG = SmsDecryptJob.class.getSimpleName();
 
-  private final long messageId;
+  private final long    messageId;
+  private final boolean manualOverride;
 
-  public SmsDecryptJob(Context context, long messageId) {
+  public SmsDecryptJob(Context context, long messageId, boolean manualOverride) {
     super(context, JobParameters.newBuilder()
                                 .withPersistence()
                                 .withRequirement(new MasterSecretRequirement(context))
                                 .create());
 
     this.messageId = messageId;
+    this.manualOverride = manualOverride;
+  }
+
+  public SmsDecryptJob(Context context, long messageId) {
+    this(context, messageId, false);
   }
 
   @Override
@@ -143,7 +149,7 @@ public class SmsDecryptJob extends MasterSecretJob {
   {
     EncryptingSmsDatabase database = DatabaseFactory.getEncryptingSmsDatabase(context);
 
-    if (SMSSecurePreferences.isAutoRespondKeyExchangeEnabled(context)) {
+    if (SMSSecurePreferences.isAutoRespondKeyExchangeEnabled(context) || manualOverride) {
       try {
         SmsCipher                  cipher   = new SmsCipher(new SMSSecureAxolotlStore(context, masterSecret));
         OutgoingKeyExchangeMessage response = cipher.process(context, message);


### PR DESCRIPTION
Disabling the option to automatically complete key exchanges makes setting up secure sessions impossible (until it's turned back on).

The message "Received key, click to process" comes up properly, except after tapping it and selecting continue, the response is not sent back.

If the option to automatically complete key exchanges is re-enabled, tapping continue will send the response.