### PR TITLE
Handling invites no longer overrides existing text

### DIFF
--- a/src/org/smssecure/smssecure/ConversationActivity.java
+++ b/src/org/smssecure/smssecure/ConversationActivity.java
@@ -355,7 +355,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   }
 
   private void handleInviteLink() {
-    composeText.setText(getString(R.string.ConversationActivity_install_smssecure, "http://smssecure.org"));
+    composeText.appendInvite(getString(R.string.ConversationActivity_install_smssecure, "http://smssecure.org"));
   }
 
   private void handleVerifyIdentity() {


### PR DESCRIPTION
Use `appendInvite` method  of `ComposeText` in place of `setText` as it takes an existing message into account.