### PR TITLE
Default to automatically completing key exchanges

### DIFF
--- a/res/xml/preferences_advanced.xml
+++ b/res/xml/preferences_advanced.xml
@@ -14,7 +14,7 @@
                         android:summary="@string/preferences__enable_this_option_if_your_keyboard_supports_emojis" />
 
     <org.smssecure.smssecure.components.SwitchPreferenceCompat
-                        android:defaultValue="false"
+                        android:defaultValue="true"
                         android:key="pref_auto_complete_key_exchange"
                         android:title="@string/preferences__complete_key_exchanges"
                         android:summary="@string/preferences__automatically_complete_key_exchanges_for_new_sessions_or_for_existing_sessions_with_the_same_identity_key" />


### PR DESCRIPTION
This was the default setting but somehow got changed (noticed this when I set up a friends device).