### PR TITLE
fix for secure incoming mms without sender, copy headers from original

### DIFF
--- a/src/org/smssecure/smssecure/jobs/MmsDownloadJob.java
+++ b/src/org/smssecure/smssecure/jobs/MmsDownloadJob.java
@@ -35,8 +35,10 @@ import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
 import ws.com.google.android.mms.MmsException;
+import ws.com.google.android.mms.pdu.EncodedStringValue;
 import ws.com.google.android.mms.pdu.MultimediaMessagePdu;
 import ws.com.google.android.mms.pdu.NotificationInd;
+import ws.com.google.android.mms.pdu.PduHeaders;
 import ws.com.google.android.mms.pdu.RetrieveConf;
 
 public class MmsDownloadJob extends MasterSecretJob {
@@ -156,7 +158,14 @@ public class MmsDownloadJob extends MasterSecretJob {
     if (retrieved.getSubject() != null && WirePrefix.isEncryptedMmsSubject(retrieved.getSubject().getString())) {
       MmsCipher            mmsCipher          = new MmsCipher(new SMSSecureAxolotlStore(context, masterSecret));
       MultimediaMessagePdu plaintextPdu       = mmsCipher.decrypt(context, retrieved);
-      RetrieveConf         plaintextRetrieved = new RetrieveConf(plaintextPdu.getPduHeaders(), plaintextPdu.getBody());
+      PduHeaders incomingHeaders = retrieved.getPduHeaders();
+      if(plaintextPdu.getPduHeaders() != null) {
+        if(plaintextPdu.getPduHeaders().getEncodedStringValue(PduHeaders.SUBJECT) != null)
+          incomingHeaders.setEncodedStringValue(plaintextPdu.getPduHeaders().getEncodedStringValue(PduHeaders.SUBJECT) , PduHeaders.SUBJECT);
+        else
+          incomingHeaders.setEncodedStringValue(new EncodedStringValue(""), PduHeaders.SUBJECT);
+      }
+      RetrieveConf         plaintextRetrieved = new RetrieveConf(incomingHeaders, plaintextPdu.getBody());
       IncomingMediaMessage plaintextMessage   = new IncomingMediaMessage(plaintextRetrieved);
 
       messageAndThreadId = database.insertSecureDecryptedMessageInbox(masterSecret, plaintextMessage,

--- a/src/org/smssecure/smssecure/mms/IncomingMediaMessage.java
+++ b/src/org/smssecure/smssecure/mms/IncomingMediaMessage.java
@@ -34,6 +34,13 @@ public class IncomingMediaMessage {
     this.push    = false;
   }
 
+  public IncomingMediaMessage(RetrieveConf retrieved, PduHeaders originalHeaders) {
+    this.headers = originalHeaders;
+    this.body    = retrieved.getBody();
+    this.groupId = null;
+    this.push    = false;
+  }
+
   public IncomingMediaMessage(MasterSecret masterSecret,
                               String from,
                               String to,


### PR DESCRIPTION
When receiving secured MMS, sender is empty because it is local unknown before encryption. Fix by copying header from original message, since this is the actual metadata of the message your receive (except for the subject, which is used to identify the session).
issue #67 