### PR TITLE
Mms size and imageresize option

### DIFF
--- a/res/values-nl/strings.xml
+++ b/res/values-nl/strings.xml
@@ -245,6 +245,7 @@ Bericht ontvangen met een onbekende identiteitssleutel. Klik om te verwerken en 
   <string name="MmsMessageRecord_decrypting_mms_please_wait">MMS ontsleutelen, een moment...</string>
   <string name="MmsMessageRecord_bad_encrypted_mms_message">Verkeerd versleuteld MMS-bericht...</string>
   <string name="MmsMessageRecord_mms_message_encrypted_for_non_existing_session">MMS-bericht versleuteld voor niet bestaande sessie...</string>
+
   <!--MuteDialog-->
   <!--ApplicationMigrationService-->
   <string name="ApplicationMigrationService_import_in_progress">Bezig met importeren</string>
@@ -483,6 +484,10 @@ Importeer een niet-versleutelde back-up voor \'SMS Back-up En Herstellen\'.</str
   <string name="preferences__about">Over SMSSecure</string>
   <string name="preferences__about_version">Versie %s</string>
   <string name="preferences__about_build_id">Build ID: %s</string>
+  <string name="preferences__mms_size">MMS grootte</string>
+  <string name="preferences__mms_limit_image">MMS foto\'s verkleinen</string>
+  <string name="preferences__mms_limit_image_disc">Schakel uit wanneer je grote foto\'s wilt versturen en je provider dit toelaat (>1MB)</string>
+  <string name="preferences__preferences_mms_size_disc">Stel hier je maximale grootte in van een MMS bericht</string>
   <!--****************************************-->
   <!--menus-->
   <!--****************************************-->

--- a/res/values-nl/strings.xml
+++ b/res/values-nl/strings.xml
@@ -487,7 +487,8 @@ Importeer een niet-versleutelde back-up voor \'SMS Back-up En Herstellen\'.</str
   <string name="preferences__mms_size">MMS grootte</string>
   <string name="preferences__mms_limit_image">MMS foto\'s verkleinen</string>
   <string name="preferences__mms_limit_image_disc">Schakel uit wanneer je grote foto\'s wilt versturen en je provider dit toelaat (>1MB)</string>
-  <string name="preferences__preferences_mms_size_disc">Stel hier je maximale grootte in van een MMS bericht</string>
+  <string name="preferences__mms_size_disc">Stel hier je maximale grootte in van een MMS bericht</string>
+  <string name="preferences__mms_size_format">kB</string>
   <!--****************************************-->
   <!--menus-->
   <!--****************************************-->

--- a/res/values-ru/strings.xml
+++ b/res/values-ru/strings.xml
@@ -459,7 +459,8 @@
   <string name="preferences__mms_size">размер ММС</string>
   <string name="preferences__mms_limit_image">уменьшить ММС фото</string>
   <string name="preferences__mms_limit_image_disc">Отключите для отправки большого изображения в случае если разрешено провайдером (>1MB)</string>
-  <string name="preferences__preferences_mms_size_disc">Укажите максимальную величину ММС</string>
+  <string name="preferences__mms_size_disc">Укажите максимальную величину ММС</string>
+  <string name="preferences__mms_size_format">кБ</string>
   <!--****************************************-->
   <!--menus-->
   <!--****************************************-->

--- a/res/values-ru/strings.xml
+++ b/res/values-ru/strings.xml
@@ -456,6 +456,10 @@
   <string name="preferences__submit_debug_log">Отправлять лог отладки</string>
   <string name="preferences__support_wifi_calling">Режим совместимости с WiFi-звонками</string>
   <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Включите, если ваше устройство отправляет и принимает SMS/MMS через WiFi (и если WiFi-звонки включены)</string>
+  <string name="preferences__mms_size">размер ММС</string>
+  <string name="preferences__mms_limit_image">уменьшить ММС фото</string>
+  <string name="preferences__mms_limit_image_disc">Отключите для отправки большого изображения в случае если разрешено провайдером (>1MB)</string>
+  <string name="preferences__preferences_mms_size_disc">Укажите максимальную величину ММС</string>
   <!--****************************************-->
   <!--menus-->
   <!--****************************************-->

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -631,6 +631,8 @@
     <string name="preferences__submit_debug_log">Submit debug log</string>
     <string name="preferences__support_wifi_calling">\'WiFi Calling\' compatibility mode</string>
     <string name="preferences__mms_size">MMS size limit</string>
+    <string name="preferences__mms_limit_image">MMS image resizing</string>
+    <string name="preferences__mms_limit_image_disc">Turn off if your carrier allows to send big pictures (>1MB)</string>
     <string name="preferences__preferences_mms_size_disc">Limit your MMS message size to your carriers needs</string>
     <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Enable if your device uses SMS/MMS delivery over WiFi (only enable when \'WiFi Calling\' is enabled on your device).</string>
     <string name="preferences__about">About SMSSecure</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -630,11 +630,6 @@
     <string name="preferences__make_textsecure_the_default_sms_mms_app">Make SMSSecure the default SMS/MMS application for your system.</string>
     <string name="preferences__submit_debug_log">Submit debug log</string>
     <string name="preferences__support_wifi_calling">\'WiFi Calling\' compatibility mode</string>
-    <string name="preferences__mms_size">MMS size limit</string>
-    <string name="preferences__mms_limit_image">MMS image resizing</string>
-    <string name="preferences__mms_limit_image_disc">Turn off if your carrier allows to send big pictures (>1MB)</string>
-    <string name="preferences__mms_size_disc">Limit your MMS message size to your carriers needs</string>
-    <string name="preferences__mms_size_format">kB</string>
     <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Enable if your device uses SMS/MMS delivery over WiFi (only enable when \'WiFi Calling\' is enabled on your device).</string>
     <string name="preferences__about">About SMSSecure</string>
     <string name="preferences__about_version">Version %s</string>
@@ -645,6 +640,11 @@
     <string name="preferences__enable_this_option_if_your_keyboard_supports_emojis">Enable this option if your keyboard supports Emojis.</string>
     <string name="preferences__show_sent_time">Show sent time</string>
     <string name="preferences__show_sent_time_instead_of_received_time_in_conversations">Show sent time instead of received time for incoming messages</string>
+    <string name="preferences__mms_size">MMS size limit</string>
+    <string name="preferences__mms_limit_image">MMS image resizing</string>
+    <string name="preferences__mms_limit_image_disc">Turn off if your carrier allows to send big pictures (>1MB)</string>
+    <string name="preferences__mms_size_disc">Limit your MMS message size to your carriers needs</string>
+    <string name="preferences__mms_size_format">kB</string>
 
     <!-- **************************************** -->
     <!-- menus -->

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -630,6 +630,8 @@
     <string name="preferences__make_textsecure_the_default_sms_mms_app">Make SMSSecure the default SMS/MMS application for your system.</string>
     <string name="preferences__submit_debug_log">Submit debug log</string>
     <string name="preferences__support_wifi_calling">\'WiFi Calling\' compatibility mode</string>
+    <string name="preferences__mms_size">MMS size limit</string>
+    <string name="preferences__preferences_mms_size_disc">Limit your MMS message size to your carriers needs</string>
     <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Enable if your device uses SMS/MMS delivery over WiFi (only enable when \'WiFi Calling\' is enabled on your device).</string>
     <string name="preferences__about">About SMSSecure</string>
     <string name="preferences__about_version">Version %s</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -633,7 +633,8 @@
     <string name="preferences__mms_size">MMS size limit</string>
     <string name="preferences__mms_limit_image">MMS image resizing</string>
     <string name="preferences__mms_limit_image_disc">Turn off if your carrier allows to send big pictures (>1MB)</string>
-    <string name="preferences__preferences_mms_size_disc">Limit your MMS message size to your carriers needs</string>
+    <string name="preferences__mms_size_disc">Limit your MMS message size to your carriers needs</string>
+    <string name="preferences__mms_size_format">kB</string>
     <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Enable if your device uses SMS/MMS delivery over WiFi (only enable when \'WiFi Calling\' is enabled on your device).</string>
     <string name="preferences__about">About SMSSecure</string>
     <string name="preferences__about_version">Version %s</string>

--- a/res/xml/preferences_sms_mms.xml
+++ b/res/xml/preferences_sms_mms.xml
@@ -41,6 +41,13 @@
                         android:title="@string/preferences__support_wifi_calling"
                         android:summary="@string/preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi"/>
 
+    <org.smssecure.smssecure.components.SwitchPreferenceCompat
+        android:defaultValue="true"
+        android:key="pref_limit_mms_image"
+        android:title="@string/preferences__mms_limit_image"
+        android:summary="@string/preferences__mms_limit_image_disc"
+        />
+
     <org.smssecure.smssecure.components.SliderPreferenceCompat
         android:defaultValue="220"
         android:max="1000"

--- a/res/xml/preferences_sms_mms.xml
+++ b/res/xml/preferences_sms_mms.xml
@@ -41,6 +41,14 @@
                         android:title="@string/preferences__support_wifi_calling"
                         android:summary="@string/preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi"/>
 
+    <org.smssecure.smssecure.components.SliderPreferenceCompat
+        android:defaultValue="220"
+        android:max="1000"
+        android:key="pref_mms_size"
+        android:title="@string/preferences__mms_size"
+        android:summary="@string/preferences__preferences_mms_size_disc"
+        />
+
     <Preference android:key="pref_mms_preferences"
                 android:title="@string/preferences__advanced_mms_access_point_names"/>
 

--- a/res/xml/preferences_sms_mms.xml
+++ b/res/xml/preferences_sms_mms.xml
@@ -53,7 +53,8 @@
         android:max="1000"
         android:key="pref_mms_size"
         android:title="@string/preferences__mms_size"
-        android:summary="@string/preferences__preferences_mms_size_disc"
+        android:text="@string/preferences__mms_size_format"
+        android:summary="@string/preferences__mms_size_disc"
         />
 
     <Preference android:key="pref_mms_preferences"

--- a/src/org/smssecure/smssecure/ApplicationContext.java
+++ b/src/org/smssecure/smssecure/ApplicationContext.java
@@ -18,6 +18,9 @@ package org.smssecure.smssecure;
 
 import android.app.Application;
 import android.content.Context;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+import android.util.Log;
 
 import org.smssecure.smssecure.crypto.PRNGFixes;
 import org.smssecure.smssecure.dependencies.AxolotlStorageModule;
@@ -25,6 +28,7 @@ import org.smssecure.smssecure.dependencies.InjectableType;
 import org.smssecure.smssecure.jobs.persistence.EncryptingJobSerializer;
 import org.smssecure.smssecure.jobs.requirements.MasterSecretRequirementProvider;
 import org.smssecure.smssecure.jobs.requirements.ServiceRequirementProvider;
+import org.smssecure.smssecure.mms.MmsMediaConstraints;
 import org.smssecure.smssecure.util.SMSSecurePreferences;
 import org.whispersystems.jobqueue.JobManager;
 import org.whispersystems.jobqueue.dependencies.DependencyInjector;
@@ -59,6 +63,11 @@ public class ApplicationContext extends Application implements DependencyInjecto
     initializeLogging();
     initializeDependencyInjection();
     initializeJobManager();
+    SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
+
+    int kiloBytes = prefs.getInt("pref_mms_size", 220);
+    if(kiloBytes > 0)
+      MmsMediaConstraints.MAX_MESSAGE_SIZE = 1024 * kiloBytes;
   }
 
   @Override

--- a/src/org/smssecure/smssecure/ApplicationContext.java
+++ b/src/org/smssecure/smssecure/ApplicationContext.java
@@ -52,9 +52,15 @@ public class ApplicationContext extends Application implements DependencyInjecto
 
   private JobManager jobManager;
   private ObjectGraph objectGraph;
+  private static Context context;
+
 
   public static ApplicationContext getInstance(Context context) {
-    return (ApplicationContext)context.getApplicationContext();
+    return (ApplicationContext) context.getApplicationContext();
+  }
+
+  public static Context get(){
+    return ApplicationContext.context;
   }
 
   @Override
@@ -63,11 +69,7 @@ public class ApplicationContext extends Application implements DependencyInjecto
     initializeLogging();
     initializeDependencyInjection();
     initializeJobManager();
-    SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
-
-    int kiloBytes = prefs.getInt("pref_mms_size", 220);
-    if(kiloBytes > 0)
-      MmsMediaConstraints.MAX_MESSAGE_SIZE = 1024 * kiloBytes;
+    ApplicationContext.context = getApplicationContext();
   }
 
   @Override

--- a/src/org/smssecure/smssecure/ApplicationPreferencesActivity.java
+++ b/src/org/smssecure/smssecure/ApplicationPreferencesActivity.java
@@ -33,6 +33,7 @@ import android.util.Log;
 import android.widget.Toast;
 
 import org.smssecure.smssecure.crypto.MasterSecret;
+import org.smssecure.smssecure.mms.MmsMediaConstraints;
 import org.smssecure.smssecure.preferences.AdvancedPreferenceFragment;
 import org.smssecure.smssecure.preferences.AppProtectionPreferenceFragment;
 import org.smssecure.smssecure.preferences.AppearancePreferenceFragment;
@@ -128,6 +129,12 @@ public class ApplicationPreferencesActivity extends PassphraseRequiredActionBarA
       Intent intent = new Intent(this, KeyCachingService.class);
       intent.setAction(KeyCachingService.LOCALE_CHANGE_EVENT);
       startService(intent);
+    }
+    if(key.equals(SMSSecurePreferences.MMS_SIZE_PREF)){
+      int kb = sharedPreferences.getInt(SMSSecurePreferences.MMS_SIZE_PREF, 220);
+      if(kb > 0){
+        MmsMediaConstraints.MAX_MESSAGE_SIZE = 1024 * kb;
+      }
     }
   }
 

--- a/src/org/smssecure/smssecure/ApplicationPreferencesActivity.java
+++ b/src/org/smssecure/smssecure/ApplicationPreferencesActivity.java
@@ -130,12 +130,6 @@ public class ApplicationPreferencesActivity extends PassphraseRequiredActionBarA
       intent.setAction(KeyCachingService.LOCALE_CHANGE_EVENT);
       startService(intent);
     }
-    if(key.equals(SMSSecurePreferences.MMS_SIZE_PREF)){
-      int kb = sharedPreferences.getInt(SMSSecurePreferences.MMS_SIZE_PREF, 220);
-      if(kb > 0){
-        MmsMediaConstraints.MAX_MESSAGE_SIZE = 1024 * kb;
-      }
-    }
   }
 
   public static class ApplicationPreferenceFragment extends PreferenceFragment {

--- a/src/org/smssecure/smssecure/ConversationActivity.java
+++ b/src/org/smssecure/smssecure/ConversationActivity.java
@@ -907,7 +907,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
       attachmentManager.clear();
 
       Toast.makeText(this, getString(R.string.ConversationActivity_sorry_the_selected_video_exceeds_message_size_restrictions,
-                                     (MmsMediaConstraints.MAX_MESSAGE_SIZE/1024)),
+                                     (MmsMediaConstraints.getMaxMmsPref()/1024)),
                      Toast.LENGTH_LONG).show();
       Log.w("ComposeMessageActivity", e);
     }
@@ -924,7 +924,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     } catch (MediaTooLargeException e) {
       attachmentManager.clear();
       Toast.makeText(this, getString(R.string.ConversationActivity_sorry_the_selected_audio_exceeds_message_size_restrictions,
-                                     (MmsMediaConstraints.MAX_MESSAGE_SIZE/1024)),
+                                     (MmsMediaConstraints.getMaxMmsPref()/1024)),
                      Toast.LENGTH_LONG).show();
       Log.w("ComposeMessageActivity", e);
     }

--- a/src/org/smssecure/smssecure/components/SliderPreferenceCompat.java
+++ b/src/org/smssecure/smssecure/components/SliderPreferenceCompat.java
@@ -27,7 +27,7 @@ public class SliderPreferenceCompat extends DialogPreference implements SeekBar.
     private TextView mSplashText,mValueText;
     private Context mContext;
 
-    private String mDialogMessage, mSuffix = "kB";
+    private String mDialogMessage, mSuffix;
     private int mDefault, mMax, mValue = 0;
 
 
@@ -41,11 +41,10 @@ public class SliderPreferenceCompat extends DialogPreference implements SeekBar.
         if(mDialogMessageId == 0) mDialogMessage = attrs.getAttributeValue(androidns, "title");
         else mDialogMessage = mContext.getString(mDialogMessageId);
 
-
-
         // Get default and max seekbar values :
         mDefault = attrs.getAttributeIntValue(androidns, "defaultValue", 220);
         mMax = attrs.getAttributeIntValue(androidns, "max", 1000);
+        mSuffix = attrs.getAttributeValue(androidns, "text");
     }
 
     @Override

--- a/src/org/smssecure/smssecure/components/SliderPreferenceCompat.java
+++ b/src/org/smssecure/smssecure/components/SliderPreferenceCompat.java
@@ -152,7 +152,6 @@ public class SliderPreferenceCompat extends DialogPreference implements SeekBar.
     public void onClick(View v) {
 
         if (shouldPersist()) {
-
             mValue = mSeekBar.getProgress();
             persistInt(mSeekBar.getProgress());
             callChangeListener(Integer.valueOf(mSeekBar.getProgress()));

--- a/src/org/smssecure/smssecure/components/SliderPreferenceCompat.java
+++ b/src/org/smssecure/smssecure/components/SliderPreferenceCompat.java
@@ -1,0 +1,164 @@
+package org.smssecure.smssecure.components;
+
+
+import android.app.AlertDialog;
+import android.content.Context;
+import android.os.Bundle;
+import android.preference.DialogPreference;
+import android.util.AttributeSet;
+import android.view.Gravity;
+import android.view.View;
+import android.view.View.OnClickListener;
+import android.widget.Button;
+import android.widget.LinearLayout;
+import android.widget.SeekBar;
+import android.widget.TextView;
+/**
+ * Created by gebruiker on 17-8-15.
+ */
+public class SliderPreferenceCompat extends DialogPreference implements SeekBar.OnSeekBarChangeListener, OnClickListener{
+
+
+    private static final String androidns="http://schemas.android.com/apk/res/android";
+
+    private SeekBar mSeekBar;
+    private TextView mSplashText,mValueText;
+    private Context mContext;
+
+    private String mDialogMessage, mSuffix = "kB";
+    private int mDefault, mMax, mValue = 0;
+    // ------------------------------------------------------------------------------------------
+
+
+
+    // ------------------------------------------------------------------------------------------
+    // Constructor :
+    public SliderPreferenceCompat(Context context, AttributeSet attrs) {
+
+        super(context,attrs);
+        mContext = context;
+
+        // Get string value for dialogMessage :
+        int mDialogMessageId = attrs.getAttributeResourceValue(androidns, "title", 0);
+        if(mDialogMessageId == 0) mDialogMessage = attrs.getAttributeValue(androidns, "title");
+        else mDialogMessage = mContext.getString(mDialogMessageId);
+
+
+
+        // Get default and max seekbar values :
+        mDefault = attrs.getAttributeIntValue(androidns, "defaultValue", 220);
+        mMax = attrs.getAttributeIntValue(androidns, "max", 1000);
+    }
+    // ------------------------------------------------------------------------------------------
+
+
+
+    // ------------------------------------------------------------------------------------------
+    // DialogPreference methods :
+    @Override
+    protected View onCreateDialogView() {
+
+        LinearLayout.LayoutParams params;
+        LinearLayout layout = new LinearLayout(mContext);
+        layout.setOrientation(LinearLayout.VERTICAL);
+        layout.setPadding(6,6,6,6);
+
+        mSplashText = new TextView(mContext);
+        mSplashText.setPadding(30, 10, 30, 10);
+        //if (mDialogMessage != null)
+        //    mSplashText.setText(mDialogMessage);
+        layout.addView(mSplashText);
+
+        mValueText = new TextView(mContext);
+        mValueText.setGravity(Gravity.CENTER_HORIZONTAL);
+        mValueText.setTextSize(32);
+        params = new LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.FILL_PARENT,
+                LinearLayout.LayoutParams.WRAP_CONTENT);
+        layout.addView(mValueText, params);
+
+        mSeekBar = new SeekBar(mContext);
+        mSeekBar.setOnSeekBarChangeListener(this);
+        layout.addView(mSeekBar, new LinearLayout.LayoutParams(LinearLayout.LayoutParams.FILL_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT));
+
+        if (shouldPersist())
+            mValue = getPersistedInt(mDefault);
+
+        mSeekBar.setMax(mMax);
+        mSeekBar.setProgress(mValue);
+
+        return layout;
+    }
+
+    @Override
+    protected void onBindDialogView(View v) {
+        super.onBindDialogView(v);
+        mSeekBar.setMax(mMax);
+        mSeekBar.setProgress(mValue);
+    }
+
+    @Override
+    protected void onSetInitialValue(boolean restore, Object defaultValue)
+    {
+        super.onSetInitialValue(restore, defaultValue);
+        if (restore)
+            mValue = shouldPersist() ? getPersistedInt(mDefault) : 0;
+        else
+            mValue = (Integer)defaultValue;
+    }
+    // ------------------------------------------------------------------------------------------
+
+
+
+    // ------------------------------------------------------------------------------------------
+    // OnSeekBarChangeListener methods :
+    @Override
+    public void onProgressChanged(SeekBar seek, int value, boolean fromTouch)
+    {
+        String t = String.valueOf(value);
+        mValueText.setText(mSuffix == null ? t : t.concat(" " + mSuffix));
+    }
+
+    @Override
+    public void onStartTrackingTouch(SeekBar seek) {}
+    @Override
+    public void onStopTrackingTouch(SeekBar seek) {}
+
+    public void setMax(int max) { mMax = max; }
+    public int getMax() { return mMax; }
+
+    public void setProgress(int progress) {
+        mValue = progress;
+        if (mSeekBar != null)
+            mSeekBar.setProgress(progress);
+    }
+    public int getProgress() { return mValue; }
+    // ------------------------------------------------------------------------------------------
+
+
+
+    // ------------------------------------------------------------------------------------------
+    // Set the positive button listener and onClick action :
+    @Override
+    public void showDialog(Bundle state) {
+
+        super.showDialog(state);
+
+        Button positiveButton = ((AlertDialog) getDialog()).getButton(AlertDialog.BUTTON_POSITIVE);
+        positiveButton.setOnClickListener(this);
+    }
+
+    @Override
+    public void onClick(View v) {
+
+        if (shouldPersist()) {
+
+            mValue = mSeekBar.getProgress();
+            persistInt(mSeekBar.getProgress());
+            callChangeListener(Integer.valueOf(mSeekBar.getProgress()));
+        }
+
+        ((AlertDialog) getDialog()).dismiss();
+    }
+    // ---------------
+}

--- a/src/org/smssecure/smssecure/components/SliderPreferenceCompat.java
+++ b/src/org/smssecure/smssecure/components/SliderPreferenceCompat.java
@@ -14,7 +14,9 @@ import android.widget.LinearLayout;
 import android.widget.SeekBar;
 import android.widget.TextView;
 /**
- * Created by gebruiker on 17-8-15.
+ * released under the APACHE 2.0 license
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  */
 public class SliderPreferenceCompat extends DialogPreference implements SeekBar.OnSeekBarChangeListener, OnClickListener{
 
@@ -27,12 +29,8 @@ public class SliderPreferenceCompat extends DialogPreference implements SeekBar.
 
     private String mDialogMessage, mSuffix = "kB";
     private int mDefault, mMax, mValue = 0;
-    // ------------------------------------------------------------------------------------------
 
 
-
-    // ------------------------------------------------------------------------------------------
-    // Constructor :
     public SliderPreferenceCompat(Context context, AttributeSet attrs) {
 
         super(context,attrs);
@@ -49,12 +47,7 @@ public class SliderPreferenceCompat extends DialogPreference implements SeekBar.
         mDefault = attrs.getAttributeIntValue(androidns, "defaultValue", 220);
         mMax = attrs.getAttributeIntValue(androidns, "max", 1000);
     }
-    // ------------------------------------------------------------------------------------------
 
-
-
-    // ------------------------------------------------------------------------------------------
-    // DialogPreference methods :
     @Override
     protected View onCreateDialogView() {
 
@@ -106,12 +99,7 @@ public class SliderPreferenceCompat extends DialogPreference implements SeekBar.
         else
             mValue = (Integer)defaultValue;
     }
-    // ------------------------------------------------------------------------------------------
 
-
-
-    // ------------------------------------------------------------------------------------------
-    // OnSeekBarChangeListener methods :
     @Override
     public void onProgressChanged(SeekBar seek, int value, boolean fromTouch)
     {
@@ -133,12 +121,7 @@ public class SliderPreferenceCompat extends DialogPreference implements SeekBar.
             mSeekBar.setProgress(progress);
     }
     public int getProgress() { return mValue; }
-    // ------------------------------------------------------------------------------------------
 
-
-
-    // ------------------------------------------------------------------------------------------
-    // Set the positive button listener and onClick action :
     @Override
     public void showDialog(Bundle state) {
 
@@ -159,5 +142,5 @@ public class SliderPreferenceCompat extends DialogPreference implements SeekBar.
 
         ((AlertDialog) getDialog()).dismiss();
     }
-    // ---------------
+
 }

--- a/src/org/smssecure/smssecure/database/MmsDatabase.java
+++ b/src/org/smssecure/smssecure/database/MmsDatabase.java
@@ -256,6 +256,10 @@ public class MmsDatabase extends MessagingDatabase {
       TelephonyManager telephonyManager = (TelephonyManager) context.getSystemService(Context.TELEPHONY_SERVICE);
       String           localNumber      = telephonyManager.getLine1Number();
 
+      if (localNumber == null) {
+        localNumber = SMSSecurePreferences.getLocalNumber(context);
+      }
+
       if (encodedCcList != null) {
         for (EncodedStringValue encodedCc : encodedCcList) {
           String cc = new String(encodedCc.getTextString(), CharacterSets.MIMENAME_ISO_8859_1);

--- a/src/org/smssecure/smssecure/database/MmsDatabase.java
+++ b/src/org/smssecure/smssecure/database/MmsDatabase.java
@@ -256,10 +256,6 @@ public class MmsDatabase extends MessagingDatabase {
       TelephonyManager telephonyManager = (TelephonyManager) context.getSystemService(Context.TELEPHONY_SERVICE);
       String           localNumber      = telephonyManager.getLine1Number();
 
-      if (localNumber == null) {
-          localNumber = SMSSecurePreferences.getLocalNumber(context);
-      }
-
       if (encodedCcList != null) {
         for (EncodedStringValue encodedCc : encodedCcList) {
           String cc = new String(encodedCc.getTextString(), CharacterSets.MIMENAME_ISO_8859_1);

--- a/src/org/smssecure/smssecure/jobs/MmsSendJob.java
+++ b/src/org/smssecure/smssecure/jobs/MmsSendJob.java
@@ -26,6 +26,7 @@ import org.smssecure.smssecure.transport.InsecureFallbackApprovalException;
 import org.smssecure.smssecure.transport.UndeliverableMessageException;
 import org.smssecure.smssecure.util.Hex;
 import org.smssecure.smssecure.util.NumberUtil;
+import org.smssecure.smssecure.util.SMSSecurePreferences;
 import org.smssecure.smssecure.util.SmilUtil;
 import org.smssecure.smssecure.util.TelephonyUtil;
 import org.whispersystems.jobqueue.JobParameters;
@@ -107,7 +108,6 @@ public class MmsSendJob extends SendJob {
   private byte[] getPduBytes(MasterSecret masterSecret, SendReq message)
       throws IOException, UndeliverableMessageException, InsecureFallbackApprovalException
   {
-    String number = TelephonyUtil.getManager(context).getLine1Number();
 
     message = getResolvedMessage(masterSecret, message, MediaConstraints.MMS_CONSTRAINTS, true);
     message.setBody(SmilUtil.getSmilBody(message.getBody()));

--- a/src/org/smssecure/smssecure/jobs/MmsSendJob.java
+++ b/src/org/smssecure/smssecure/jobs/MmsSendJob.java
@@ -109,6 +109,8 @@ public class MmsSendJob extends SendJob {
       throws IOException, UndeliverableMessageException, InsecureFallbackApprovalException
   {
 
+    String number = TelephonyUtil.getManager(context).getLine1Number();
+
     message = getResolvedMessage(masterSecret, message, MediaConstraints.MMS_CONSTRAINTS, true);
     message.setBody(SmilUtil.getSmilBody(message.getBody()));
 

--- a/src/org/smssecure/smssecure/mms/AudioSlide.java
+++ b/src/org/smssecure/smssecure/mms/AudioSlide.java
@@ -59,7 +59,7 @@ public class AudioSlide extends Slide {
   public static PduPart constructPartFromUri(Context context, Uri uri) throws IOException, MediaTooLargeException {
     PduPart part = new PduPart();
 
-    assertMediaSize(context, uri, MmsMediaConstraints.MAX_MESSAGE_SIZE);
+    assertMediaSize(context, uri, MmsMediaConstraints.getMaxMmsPref());
 
     Cursor cursor = null;
 

--- a/src/org/smssecure/smssecure/mms/LegacyMmsConnection.java
+++ b/src/org/smssecure/smssecure/mms/LegacyMmsConnection.java
@@ -195,6 +195,7 @@ public abstract class LegacyMmsConnection {
 
   protected List<Header> getBaseHeaders() {
     final String number = TelephonyUtil.getManager(context).getLine1Number();
+
     return new LinkedList<Header>() {{
       add(new BasicHeader("Accept", "*/*, application/vnd.wap.mms-message, application/vnd.wap.sic"));
       add(new BasicHeader("x-wap-profile", "http://www.google.com/oha/rdf/ua-profile-kila.xml"));

--- a/src/org/smssecure/smssecure/mms/LegacyMmsConnection.java
+++ b/src/org/smssecure/smssecure/mms/LegacyMmsConnection.java
@@ -195,7 +195,6 @@ public abstract class LegacyMmsConnection {
 
   protected List<Header> getBaseHeaders() {
     final String number = TelephonyUtil.getManager(context).getLine1Number();
-
     return new LinkedList<Header>() {{
       add(new BasicHeader("Accept", "*/*, application/vnd.wap.mms-message, application/vnd.wap.sic"));
       add(new BasicHeader("x-wap-profile", "http://www.google.com/oha/rdf/ua-profile-kila.xml"));

--- a/src/org/smssecure/smssecure/mms/MediaConstraints.java
+++ b/src/org/smssecure/smssecure/mms/MediaConstraints.java
@@ -1,7 +1,9 @@
 package org.smssecure.smssecure.mms;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.net.Uri;
+import android.preference.PreferenceManager;
 import android.util.Log;
 import android.util.Pair;
 

--- a/src/org/smssecure/smssecure/mms/MmsMediaConstraints.java
+++ b/src/org/smssecure/smssecure/mms/MmsMediaConstraints.java
@@ -1,19 +1,32 @@
 package org.smssecure.smssecure.mms;
 
+import android.app.Application;
 import android.content.Context;
 
+import org.smssecure.smssecure.ApplicationContext;
+import org.smssecure.smssecure.util.SMSSecurePreferences;
 import org.smssecure.smssecure.util.Util;
 
 
 public class MmsMediaConstraints extends MediaConstraints {
   private static final int MAX_IMAGE_DIMEN_LOWMEM = 768;
   private static final int MAX_IMAGE_DIMEN        = 1024;
-  public static int MAX_MESSAGE_SIZE       = 220 * 1024;
+  public static int FALLBACK_MAX_MESSAGE_SIZE       = 220 * 1024;
 
+  public static int getMaxMmsPref(){
+    int kB = SMSSecurePreferences.getMmmMaxSize(ApplicationContext.get());
+    if(kB > 0)
+      return(1024*kB);
+    else return FALLBACK_MAX_MESSAGE_SIZE;
+  }
 
   @Override
   public int getImageMaxWidth(Context context) {
-    return Util.isLowMemory(context) ? MAX_IMAGE_DIMEN_LOWMEM : MAX_IMAGE_DIMEN;
+    boolean limitedImageSize = SMSSecurePreferences.getLimitedMmsImageDimensions(ApplicationContext.get());
+    if(limitedImageSize)
+      return Util.isLowMemory(context) ? MAX_IMAGE_DIMEN_LOWMEM : MAX_IMAGE_DIMEN;
+    else
+      return Integer.MAX_VALUE;
   }
 
   @Override
@@ -23,27 +36,22 @@ public class MmsMediaConstraints extends MediaConstraints {
 
   @Override
   public int getImageMaxSize() {
-    return MAX_MESSAGE_SIZE;
+    return getMaxMmsPref();
   }
 
   @Override
   public int getGifMaxSize() {
-    return MAX_MESSAGE_SIZE;
+    return getMaxMmsPref();
   }
 
   @Override
   public int getVideoMaxSize() {
-    return MAX_MESSAGE_SIZE;
+    return getMaxMmsPref();
   }
 
   @Override
   public int getAudioMaxSize() {
-    return MAX_MESSAGE_SIZE;
-  }
-
-  public static void setMaxSize(int kiloBytes){
-    if(kiloBytes > 0)
-      MAX_MESSAGE_SIZE = kiloBytes * 1024;
+    return getMaxMmsPref();
   }
 
 }

--- a/src/org/smssecure/smssecure/mms/MmsMediaConstraints.java
+++ b/src/org/smssecure/smssecure/mms/MmsMediaConstraints.java
@@ -4,10 +4,12 @@ import android.content.Context;
 
 import org.smssecure.smssecure.util.Util;
 
+
 public class MmsMediaConstraints extends MediaConstraints {
   private static final int MAX_IMAGE_DIMEN_LOWMEM = 768;
   private static final int MAX_IMAGE_DIMEN        = 1024;
-  public  static final int MAX_MESSAGE_SIZE       = 280 * 1024;
+  public static int MAX_MESSAGE_SIZE       = 220 * 1024;
+
 
   @Override
   public int getImageMaxWidth(Context context) {
@@ -38,4 +40,10 @@ public class MmsMediaConstraints extends MediaConstraints {
   public int getAudioMaxSize() {
     return MAX_MESSAGE_SIZE;
   }
+
+  public static void setMaxSize(int kiloBytes){
+    if(kiloBytes > 0)
+      MAX_MESSAGE_SIZE = kiloBytes * 1024;
+  }
+
 }

--- a/src/org/smssecure/smssecure/mms/PushMediaConstraints.java
+++ b/src/org/smssecure/smssecure/mms/PushMediaConstraints.java
@@ -32,11 +32,11 @@ public class PushMediaConstraints extends MediaConstraints {
 
   @Override
   public int getVideoMaxSize() {
-    return MmsMediaConstraints.MAX_MESSAGE_SIZE;
+    return MmsMediaConstraints.getMaxMmsPref();
   }
 
   @Override
   public int getAudioMaxSize() {
-    return MmsMediaConstraints.MAX_MESSAGE_SIZE;
+    return MmsMediaConstraints.getMaxMmsPref();
   }
 }

--- a/src/org/smssecure/smssecure/mms/VideoSlide.java
+++ b/src/org/smssecure/smssecure/mms/VideoSlide.java
@@ -76,7 +76,7 @@ public class VideoSlide extends Slide {
         cursor.close();
     }
 
-    assertMediaSize(context, uri, MmsMediaConstraints.MAX_MESSAGE_SIZE);
+    assertMediaSize(context, uri, MmsMediaConstraints.getMaxMmsPref());
     part.setDataUri(uri);
     part.setContentId((System.currentTimeMillis()+"").getBytes());
     part.setName(("Video" + System.currentTimeMillis()).getBytes());

--- a/src/org/smssecure/smssecure/util/SMSSecurePreferences.java
+++ b/src/org/smssecure/smssecure/util/SMSSecurePreferences.java
@@ -79,7 +79,8 @@ public class SMSSecurePreferences {
   private static final String PUSH_REGISTRATION_REMINDER_PREF  = "pref_push_registration_reminder";
   private static final String RATING_LATER_PREF                = "pref_rating_later";
   private static final String RATING_ENABLED_PREF              = "pref_rating_enabled";
-  public  static final String NOTIFICATION_PRIVACY_PREF        = "pref_notification_privacy";
+  public static final String NOTIFICATION_PRIVACY_PREF        = "pref_notification_privacy";
+  public static final String MMS_SIZE_PREF                     = "pref_mms_size";
 
   public static NotificationPrivacyPreference getNotificationPrivacy(Context context) {
     return new NotificationPrivacyPreference(getStringPreference(context, NOTIFICATION_PRIVACY_PREF, "all"));

--- a/src/org/smssecure/smssecure/util/SMSSecurePreferences.java
+++ b/src/org/smssecure/smssecure/util/SMSSecurePreferences.java
@@ -79,8 +79,9 @@ public class SMSSecurePreferences {
   private static final String PUSH_REGISTRATION_REMINDER_PREF  = "pref_push_registration_reminder";
   private static final String RATING_LATER_PREF                = "pref_rating_later";
   private static final String RATING_ENABLED_PREF              = "pref_rating_enabled";
-  public static final String NOTIFICATION_PRIVACY_PREF        = "pref_notification_privacy";
+  public static final String NOTIFICATION_PRIVACY_PREF         = "pref_notification_privacy";
   public static final String MMS_SIZE_PREF                     = "pref_mms_size";
+  public static final String LIMIT_IMAGE_SIZE_PREF             = "pref_limit_mms_image";
 
   public static NotificationPrivacyPreference getNotificationPrivacy(Context context) {
     return new NotificationPrivacyPreference(getStringPreference(context, NOTIFICATION_PRIVACY_PREF, "all"));
@@ -88,6 +89,14 @@ public class SMSSecurePreferences {
 
   public static long getRatingLaterTimestamp(Context context) {
     return getLongPreference(context, RATING_LATER_PREF, 0);
+  }
+
+  public static int getMmmMaxSize(Context context){
+    return getIntegerPreference(context, MMS_SIZE_PREF, 220);
+  }
+
+  public static boolean getLimitedMmsImageDimensions(Context context){
+    return getBooleanPreference(context, LIMIT_IMAGE_SIZE_PREF, true);
   }
 
   public static void setRatingLaterTimestamp(Context context, long timestamp) {
@@ -494,6 +503,9 @@ public class SMSSecurePreferences {
   }
 
   public static boolean getBooleanPreference(Context context, String key, boolean defaultValue) {
+    if(context == null){
+      return defaultValue;
+    }
     return PreferenceManager.getDefaultSharedPreferences(context).getBoolean(key, defaultValue);
   }
 
@@ -502,10 +514,16 @@ public class SMSSecurePreferences {
   }
 
   public static String getStringPreference(Context context, String key, String defaultValue) {
+    if(context == null){
+      return defaultValue;
+    }
     return PreferenceManager.getDefaultSharedPreferences(context).getString(key, defaultValue);
   }
 
   private static int getIntegerPreference(Context context, String key, int defaultValue) {
+    if(context == null){
+      return defaultValue;
+    }
     return PreferenceManager.getDefaultSharedPreferences(context).getInt(key, defaultValue);
   }
 
@@ -518,6 +536,9 @@ public class SMSSecurePreferences {
   }
 
   private static long getLongPreference(Context context, String key, long defaultValue) {
+    if(context == null){
+      return defaultValue;
+    }
     return PreferenceManager.getDefaultSharedPreferences(context).getLong(key, defaultValue);
   }
 

--- a/src/org/smssecure/smssecure/util/SaveAttachmentTask.java
+++ b/src/org/smssecure/smssecure/util/SaveAttachmentTask.java
@@ -119,7 +119,7 @@ public class SaveAttachmentTask extends ProgressDialogAsyncTask<SaveAttachmentTa
     MimeTypeMap       mimeTypeMap   = MimeTypeMap.getSingleton();
     String            extension     = mimeTypeMap.getExtensionFromMimeType(contentType);
     SimpleDateFormat  dateFormatter = new SimpleDateFormat("yyyy-MM-dd-HHmmss");
-    String            base          = "textsecure-" + dateFormatter.format(timestamp);
+    String            base          = "smssecure-" + dateFormatter.format(timestamp);
 
     if (extension == null)
       extension = "attach";


### PR DESCRIPTION
Added option to disable image resizing if your plan allows bigger (sized) images. Also added a slider to change the maximum MMS size. My provider only allows 300kb messages and as the messages unencrypted stay below 280k, encrypted version might sometimes go over 300kb. So I added a slider to configure this limit. 

ps. My first ever android development so might have overseen something in the preferences. Let me know, but seems to work fine.