### PR TITLE
LED doesn't blink with encryption enabled #261

### DIFF
--- a/src/org/smssecure/smssecure/TransportOptions.java
+++ b/src/org/smssecure/smssecure/TransportOptions.java
@@ -5,6 +5,7 @@ import android.content.res.TypedArray;
 
 import org.smssecure.smssecure.util.MmsCharacterCalculator;
 import org.smssecure.smssecure.util.SmsCharacterCalculator;
+import org.smssecure.smssecure.util.EncryptedSmsCharacterCalculator;
 import org.whispersystems.libaxolotl.util.guava.Optional;
 
 import java.util.LinkedList;
@@ -104,7 +105,7 @@ public class TransportOptions {
                                       context.getResources().getColor(R.color.smssecure_primary),
                                       context.getString(R.string.ConversationActivity_transport_secure_sms),
                                       context.getString(R.string.conversation_activity__type_message_sms_secure),
-                                      new SmsCharacterCalculator()));
+                                      new EncryptedSmsCharacterCalculator()));
     }
 
     return results;

--- a/src/org/smssecure/smssecure/jobs/SmsDecryptJob.java
+++ b/src/org/smssecure/smssecure/jobs/SmsDecryptJob.java
@@ -59,11 +59,7 @@ public class SmsDecryptJob extends MasterSecretJob {
   }
 
   @Override
-  public void onAdded() {
-    if (KeyCachingService.getMasterSecret(context) == null) {
-      MessageNotifier.updateNotification(context, null, -2);
-    }
-  }
+  public void onAdded() {}
 
   @Override
   public void onRun(MasterSecret masterSecret) throws NoSuchMessageException {

--- a/src/org/smssecure/smssecure/jobs/SmsReceiveJob.java
+++ b/src/org/smssecure/smssecure/jobs/SmsReceiveJob.java
@@ -92,8 +92,6 @@ public class SmsReceiveJob extends ContextJob {
       ApplicationContext.getInstance(context)
                         .getJobManager()
                         .add(new SmsDecryptJob(context, messageAndThreadId.first));
-    } else {
-      MessageNotifier.updateNotification(context, masterSecret, messageAndThreadId.second);
     }
 
     return messageAndThreadId;

--- a/src/org/smssecure/smssecure/notifications/AbstractNotificationBuilder.java
+++ b/src/org/smssecure/smssecure/notifications/AbstractNotificationBuilder.java
@@ -37,13 +37,9 @@ public abstract class AbstractNotificationBuilder extends NotificationCompat.Bui
     return builder;
   }
 
-  public void setAlarms(@Nullable Uri ringtone, RecipientPreferenceDatabase.VibrateState vibrate) {
+  public void setAudibleAlarms(@Nullable Uri ringtone, RecipientPreferenceDatabase.VibrateState vibrate) {
     String defaultRingtoneName   = SMSSecurePreferences.getNotificationRingtone(context);
     boolean defaultVibrate       = SMSSecurePreferences.isNotificationVibrateEnabled(context);
-    String ledColor              = SMSSecurePreferences.getNotificationLedColor(context);
-    String ledBlinkPattern       = SMSSecurePreferences.getNotificationLedPattern(context);
-    String ledBlinkPatternCustom = SMSSecurePreferences.getNotificationLedPatternCustom(context);
-    String[] blinkPatternArray   = parseBlinkPattern(ledBlinkPattern, ledBlinkPatternCustom);
 
     if      (ringtone != null)                        setSound(ringtone);
     else if (!TextUtils.isEmpty(defaultRingtoneName)) setSound(Uri.parse(defaultRingtoneName));
@@ -53,6 +49,14 @@ public abstract class AbstractNotificationBuilder extends NotificationCompat.Bui
     {
       setDefaults(Notification.DEFAULT_VIBRATE);
     }
+
+  }
+
+  public void setVisualAlarms() {
+    String ledColor              = SMSSecurePreferences.getNotificationLedColor(context);
+    String ledBlinkPattern       = SMSSecurePreferences.getNotificationLedPattern(context);
+    String ledBlinkPatternCustom = SMSSecurePreferences.getNotificationLedPatternCustom(context);
+    String[] blinkPatternArray   = parseBlinkPattern(ledBlinkPattern, ledBlinkPatternCustom);
 
     if (!ledColor.equals("none")) {
       setLights(Color.parseColor(ledColor),

--- a/src/org/smssecure/smssecure/notifications/FailedNotificationBuilder.java
+++ b/src/org/smssecure/smssecure/notifications/FailedNotificationBuilder.java
@@ -22,7 +22,8 @@ public class FailedNotificationBuilder extends AbstractNotificationBuilder {
     setTicker(context.getString(R.string.MessageNotifier_error_delivering_message));
     setContentIntent(PendingIntent.getActivity(context, 0, intent, 0));
     setAutoCancel(true);
-    setAlarms(null, RecipientPreferenceDatabase.VibrateState.DEFAULT);
+    setAudibleAlarms(null, RecipientPreferenceDatabase.VibrateState.DEFAULT);
+    setVisualAlarms();
   }
 
 

--- a/src/org/smssecure/smssecure/notifications/MarkReadReceiver.java
+++ b/src/org/smssecure/smssecure/notifications/MarkReadReceiver.java
@@ -29,8 +29,7 @@ public class MarkReadReceiver extends MasterSecretBroadcastReceiver {
     if (threadIds != null) {
       Log.w("TAG", "threadIds length: " + threadIds.length);
 
-      ((NotificationManager)context.getSystemService(Context.NOTIFICATION_SERVICE))
-                                   .cancel(MessageNotifier.NOTIFICATION_ID);
+      MessageNotifier.cancelNotification(context);
 
       new AsyncTask<Void, Void, Void>() {
         @Override


### PR DESCRIPTION
Hello,

I did some changes to the way notifications work in order to fix this issue and issue #203. The reason for so many changes is that there are some harder use-cases (for example the led was turned off when the pass-phrase timeout kicked in as well). The changes seem to work for me but it would be nice for someone else to test this as well.

Thanks!

git commit message:

Notifications in SMSSecure seem to rely mainly on two public methods:

MessageNotifier.updateNotification(Context, MasterSecret, long) and
MessageNotifier.updateNotification(Context, MasterSecret)

The difference between them is that the first is also aware of in thread
notifications and triggers visual and audible alarms. Since the second
method doesn't call setLights, calling it after the first will cause the
blinking lights to stop. This patch changes a number of things:
- separate the alarms into visual and audio alarms.
- so long as the notification is not canceled, make the second method also
  call setLights if the first method was previously called.
- removed unnecessary calls to the first method to avoid duplicate sound
  alarms.