### PR TITLE
Character counter doesn't work properly since 0.10.0 #279

### DIFF
--- a/src/org/smssecure/smssecure/TransportOptions.java
+++ b/src/org/smssecure/smssecure/TransportOptions.java
@@ -5,6 +5,7 @@ import android.content.res.TypedArray;
 
 import org.smssecure.smssecure.util.MmsCharacterCalculator;
 import org.smssecure.smssecure.util.SmsCharacterCalculator;
+import org.smssecure.smssecure.util.EncryptedSmsCharacterCalculator;
 import org.whispersystems.libaxolotl.util.guava.Optional;
 
 import java.util.LinkedList;
@@ -104,7 +105,7 @@ public class TransportOptions {
                                       context.getResources().getColor(R.color.smssecure_primary),
                                       context.getString(R.string.ConversationActivity_transport_secure_sms),
                                       context.getString(R.string.conversation_activity__type_message_sms_secure),
-                                      new SmsCharacterCalculator()));
+                                      new EncryptedSmsCharacterCalculator()));
     }
 
     return results;


### PR DESCRIPTION
Currently both secure and insecure SMS messages are using
SmsCharacterCalculator to calculate remaining characters.
Use EncryptedSmsCharacterCalculator for secure messages.