### PR TITLE
allow "panic button" apps to lock SMSSecure

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -220,6 +220,16 @@
               android:theme="@style/SMSSecure.LightTheme"
               android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize"/>
 
+    <activity android:name=".PanicResponderActivity"
+              android:launchMode="singleInstance"
+              android:noHistory="true"
+              android:theme="@android:style/Theme.NoDisplay">
+        <intent-filter>
+            <action android:name="info.guardianproject.panic.action.TRIGGER" />
+            <category android:name="android.intent.category.DEFAULT" />
+        </intent-filter>
+    </activity>
+
     <service android:enabled="true" android:name=".service.ApplicationMigrationService"/>
     <service android:enabled="true" android:name=".service.KeyCachingService"/>
 

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -230,6 +230,9 @@
         </intent-filter>
     </activity>
 
+    <activity android:name=".ExitActivity"
+              android:theme="@android:style/Theme.NoDisplay" />
+
     <service android:enabled="true" android:name=".service.ApplicationMigrationService"/>
     <service android:enabled="true" android:name=".service.KeyCachingService"/>
 

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     compile 'se.emilsjolander:stickylistheaders:2.7.0'
     compile 'com.jpardogo.materialtabstrip:library:1.0.9'
     compile project (':libs:org.w3c.dom')
+    compile 'info.guardianproject.trustedintents:trustedintents:0.1'
     compile 'org.apache.httpcomponents:httpclient-android:4.3.5'
     compile 'com.github.chrisbanes.photoview:library:1.2.3'
     compile 'com.github.bumptech.glide:glide:3.6.1'
@@ -96,6 +97,7 @@ dependencyVerification {
             'com.makeramen:roundedimageview:1f5a1865796b308c6cdd114acc6e78408b110f0a62fc63553278fbeacd489cd1',
             'com.pnikosis:materialish-progress:d71d80e00717a096784482aee21001a9d299fec3833e4ebd87739ed36cf77c54',
             'de.greenrobot:eventbus:61d743a748156a372024d083de763b9e91ac2dcb3f6a1cbc74995c7ddab6e968',
+            'info.guardianproject.trustedintents:trustedintents:7fbf1cec04f0fa8286e4842c0b8f9f65e522f78a35ae4892da17405601f7adda',
             'com.melnykov:floatingactionbutton:15d58d4fac0f7a288d0e5301bbaf501a146f5b3f5921277811bf99bd3b397263',
             'com.nineoldandroids:library:68025a14e3e7673d6ad2f95e4b46d78d7d068343aa99256b686fe59de1b3163a',
             'com.squareup.dagger:dagger:789aca24537022e49f91fc6444078d9de8f1dd99e1bfb090f18491b186967883',

--- a/src/org/smssecure/smssecure/ExitActivity.java
+++ b/src/org/smssecure/smssecure/ExitActivity.java
@@ -1,0 +1,34 @@
+
+package org.smssecure.smssecure;
+
+import android.content.Intent;
+import android.app.Activity;
+import android.os.Build;
+import android.os.Bundle;
+
+public class ExitActivity extends Activity {
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    if (Build.VERSION.SDK_INT >= 21) {
+      finishAndRemoveTask();
+    } else {
+      finish();
+    }
+
+    System.exit(0);
+  }
+
+  public static void exitAndRemoveFromRecentApps(Activity activity) {
+    Intent intent = new Intent(activity, ExitActivity.class);
+
+    intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK
+            | Intent.FLAG_ACTIVITY_CLEAR_TASK
+            | Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS
+            | Intent.FLAG_ACTIVITY_NO_ANIMATION);
+
+    activity.startActivity(intent);
+  }
+}

--- a/src/org/smssecure/smssecure/PanicResponderActivity.java
+++ b/src/org/smssecure/smssecure/PanicResponderActivity.java
@@ -1,0 +1,50 @@
+package org.smssecure.smssecure;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Build;
+import android.os.Bundle;
+
+import org.iilab.IilabEngineeringRSA2048Pin;
+import org.smssecure.smssecure.service.KeyCachingService;
+import org.smssecure.smssecure.util.SMSSecurePreferences;
+
+import info.guardianproject.GuardianProjectRSA4096;
+import info.guardianproject.trustedintents.TrustedIntents;
+
+public class PanicResponderActivity extends Activity {
+
+  private static final String TAG = PanicResponderActivity.class.getSimpleName();
+
+  public static final String PANIC_TRIGGER_ACTION = "info.guardianproject.panic.action.TRIGGER";
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    TrustedIntents trustedIntents = TrustedIntents.get(this);
+    // Guardian Project Ripple
+    trustedIntents.addTrustedSigner(GuardianProjectRSA4096.class);
+    // Amnesty International's Panic Button, made by iilab.org
+    trustedIntents.addTrustedSigner(IilabEngineeringRSA2048Pin.class);
+
+    Intent intent = trustedIntents.getIntentFromTrustedSender(this);
+    if (intent != null
+            && !SMSSecurePreferences.isPasswordDisabled(this)
+            && PANIC_TRIGGER_ACTION.equals(intent.getAction())) {
+      handleClearPassphrase();
+    }
+
+    if (Build.VERSION.SDK_INT >= 21) {
+      finishAndRemoveTask();
+    } else {
+      finish();
+    }
+  }
+
+  private void handleClearPassphrase() {
+    Intent intent = new Intent(this, KeyCachingService.class);
+    intent.setAction(KeyCachingService.CLEAR_KEY_ACTION);
+    startService(intent);
+  }
+}

--- a/src/org/smssecure/smssecure/PanicResponderActivity.java
+++ b/src/org/smssecure/smssecure/PanicResponderActivity.java
@@ -33,6 +33,7 @@ public class PanicResponderActivity extends Activity {
             && !SMSSecurePreferences.isPasswordDisabled(this)
             && PANIC_TRIGGER_ACTION.equals(intent.getAction())) {
       handleClearPassphrase();
+      ExitActivity.exitAndRemoveFromRecentApps(this);
     }
 
     if (Build.VERSION.SDK_INT >= 21) {


### PR DESCRIPTION
We've been developing "panic button" features in our apps for years, and now we are working to make a more flexible and open ecosystem of apps that can both trigger other apps, or respond to triggers.  Since SMSSecure already includes a "lock" feature, it is a natural panic responder app.  This setup allows for easy configuration of a single trigger action which can then trigger multiple apps.

The first commit adds support for receiving the panic trigger.  The second commit wipes SMSSecure from the Recent Apps when it is responding to a panic trigger.

More info on the panic kit work here:
https://dev.guardianproject.info/projects/panic/wiki

The first panic button app that sends this kind of trigger is called Ripple, and it is available here:
https://github.com/guardianproject/ripple
https://play.google.com/store/apps/details?id=info.guardianproject.ripple
https://guardianproject.info/fdroid

I'm adding support to this app right now:
https://panicbutton.io/
https://play.google.com/store/apps/details?id=org.iilab.pb

This is all code that I wrote, and you can have it under any license you want, including public domain.  I waive all my copyright claims to it.