### PR TITLE
make gradle wrapper verify the gradle binary it downloads and executes

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -4,3 +4,4 @@ distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-2.8-bin.zip
+distributionSha256Sum=a88db9c2f104defdaa8011c58cf6cda6c114298ae3695ecfb8beb30da3a903cb


### PR DESCRIPTION
https://docs.gradle.org/current/userguide/gradle_wrapper.html#sec:verification

In order for this change to take effect, the gradle wrapper needs to be
regenerated using gradle 2.6 or newer:
https://docs.gradle.org/current/userguide/gradle_wrapper.html

I checked the hash against what fdroid has:
https://gitlab.com/fdroid/fdroidserver/blob/0.5.0/makebuildserver#L117