### PR TITLE
remove launchMode="singleInstance" to get panic response working

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -231,8 +231,8 @@
               android:theme="@style/SMSSecure.LightTheme"
               android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize"/>
 
+    <!-- this can never have launchMode singleTask or singleInstance! -->
     <activity android:name=".PanicResponderActivity"
-              android:launchMode="singleInstance"
               android:noHistory="true"
               android:theme="@android:style/Theme.NoDisplay">
         <intent-filter>


### PR DESCRIPTION
If an Activity is set to singleInstance, then it immediately sends a cancel to the Activity that called with startActivityForResult(), therefore this Activity cannot get the sender of the Intent. getCallingActivity() returns null.

"[I]f the activity you are launching uses the singleTask launch mode, it will not run in your task and thus you will immediately receive a cancel result."
https://developer.android.com/reference/android/app/Activity.html#startActivityForResult%28android.content.Intent,%20int,%20android.os.Bundle%29