### PR TITLE
use TrustedIntents v0.2 to fix bug where it never allowed receiving

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     compile 'se.emilsjolander:stickylistheaders:2.7.0'
     compile 'com.jpardogo.materialtabstrip:library:1.0.9'
     compile project (':libs:org.w3c.dom')
-    compile 'info.guardianproject.trustedintents:trustedintents:0.1'
+    compile 'info.guardianproject.trustedintents:trustedintents:0.2'
     compile 'org.apache.httpcomponents:httpclient-android:4.3.5'
     compile 'com.github.chrisbanes.photoview:library:1.2.3'
     compile 'com.github.bumptech.glide:glide:3.6.1'
@@ -98,7 +98,7 @@ dependencyVerification {
             'com.makeramen:roundedimageview:1f5a1865796b308c6cdd114acc6e78408b110f0a62fc63553278fbeacd489cd1',
             'com.pnikosis:materialish-progress:d71d80e00717a096784482aee21001a9d299fec3833e4ebd87739ed36cf77c54',
             'de.greenrobot:eventbus:61d743a748156a372024d083de763b9e91ac2dcb3f6a1cbc74995c7ddab6e968',
-            'info.guardianproject.trustedintents:trustedintents:7fbf1cec04f0fa8286e4842c0b8f9f65e522f78a35ae4892da17405601f7adda',
+            'info.guardianproject.trustedintents:trustedintents:6221456d8821a8d974c2acf86306900237cf6afaaa94a4c9c44e161350f80f3e',
             'com.melnykov:floatingactionbutton:15d58d4fac0f7a288d0e5301bbaf501a146f5b3f5921277811bf99bd3b397263',
             'com.nineoldandroids:library:68025a14e3e7673d6ad2f95e4b46d78d7d068343aa99256b686fe59de1b3163a',
             'com.squareup.dagger:dagger:789aca24537022e49f91fc6444078d9de8f1dd99e1bfb090f18491b186967883',


### PR DESCRIPTION
This update to the library fixes a bug where it would always check for the app's own packageName (e.g. org.smssecure.smssecure) instead of the sender's packageName (e.g. info.guardianproject.ripple), so in this case, the Intent was never trusted.