### PR TITLE
ISSUE-366 fixes dualsim transport options filter

### DIFF
--- a/src/org/smssecure/smssecure/TransportOptions.java
+++ b/src/org/smssecure/smssecure/TransportOptions.java
@@ -99,11 +99,10 @@ public class TransportOptions {
   }
 
   public void disableTransport(Type type) {
-    Optional<TransportOption> option = find(type);
+    List<TransportOption> options = find(type);
 
-    if (option.isPresent()) {
-      enabledTransports.remove(option.get());
-
+    for (TransportOption option : options) {
+      enabledTransports.remove(option);
       if (selectedOption.isPresent() && selectedOption.get().getType() == type) {
         setSelectedTransport(null);
       }
@@ -188,14 +187,14 @@ public class TransportOptions {
     }
   }
 
-  private Optional<TransportOption> find(Type type) {
+  private List<TransportOption> find(Type type) {
+    List<TransportOption> options = new LinkedList<>();
     for (TransportOption option : enabledTransports) {
       if (option.isType(type)) {
-        return Optional.of(option);
+        options.add(option);
       }
     }
-
-    return Optional.absent();
+    return options;
   }
 
   private boolean isEnabled(TransportOption transportOption) {


### PR DESCRIPTION
On a dualsim phone, both secure_sms transports will be hidden with this patch.
Fixes #366 